### PR TITLE
Fix crl check

### DIFF
--- a/cert.go
+++ b/cert.go
@@ -486,18 +486,13 @@ func (p *PKCS7) loadCertificateStack(sk *C.struct_stack_st_X509) error {
 
 // VerifyTrustAndGetIssuerCertificate takes a CertificateStore and verifies trust for the certificate.
 // The issuing certificate from the CertificateStore is returned if found.
-func (c *Certificate) VerifyTrustAndGetIssuerCertificate(store *CertificateStore, crlCheck bool) (*Certificate, VerifyResult, error) {
+func (c *Certificate) VerifyTrustAndGetIssuerCertificate(store *CertificateStore) (*Certificate, VerifyResult, error) {
 	storeCtx := C.X509_STORE_CTX_new()
 	if storeCtx == nil {
 		return nil, 0, errors.New("failed to create new X509_STORE_CTX")
 	}
 	defer C.X509_STORE_CTX_free(storeCtx)
 
-	flags := C.ulong(0)
-	if crlCheck {
-		flags = C.X509_V_FLAG_CRL_CHECK
-	}
-	C.X509_STORE_set_flags(store.store, flags)
 	rc := C.X509_STORE_CTX_init(storeCtx, store.store, c.x, nil)
 	if rc == 0 {
 		return nil, 0, errors.New("unable to init X509_STORE_CTX")

--- a/ctx.go
+++ b/ctx.go
@@ -326,6 +326,37 @@ func (s *CertificateStore) AddCRL(crl *CRL) error {
 	return nil
 }
 
+type VerifyFlags int
+
+const (
+	CBIssuerCheck      VerifyFlags = C.X509_V_FLAG_CB_ISSUER_CHECK
+	UseCheckTime       VerifyFlags = C.X509_V_FLAG_USE_CHECK_TIME
+	CRLCheck           VerifyFlags = C.X509_V_FLAG_CRL_CHECK
+	CRLCheckAll        VerifyFlags = C.X509_V_FLAG_CRL_CHECK_ALL
+	IgnoreCritical     VerifyFlags = C.X509_V_FLAG_IGNORE_CRITICAL
+	X509Strict         VerifyFlags = C.X509_V_FLAG_X509_STRICT
+	AllowProxyCerts    VerifyFlags = C.X509_V_FLAG_ALLOW_PROXY_CERTS
+	PolicyCheck        VerifyFlags = C.X509_V_FLAG_POLICY_CHECK
+	ExplicitPolicy     VerifyFlags = C.X509_V_FLAG_EXPLICIT_POLICY
+	InhibitAny         VerifyFlags = C.X509_V_FLAG_INHIBIT_ANY
+	InhibitMap         VerifyFlags = C.X509_V_FLAG_INHIBIT_MAP
+	NotifyPolicy       VerifyFlags = C.X509_V_FLAG_NOTIFY_POLICY
+	ExtendedCRLSupport VerifyFlags = C.X509_V_FLAG_EXTENDED_CRL_SUPPORT
+	UseDeltas          VerifyFlags = C.X509_V_FLAG_USE_DELTAS
+	CheckSSSignature   VerifyFlags = C.X509_V_FLAG_CHECK_SS_SIGNATURE
+	TrustedFirst       VerifyFlags = C.X509_V_FLAG_TRUSTED_FIRST
+	SuiteB128LOSOnly   VerifyFlags = C.X509_V_FLAG_SUITEB_128_LOS_ONLY
+	SuiteB192LOS       VerifyFlags = C.X509_V_FLAG_SUITEB_192_LOS
+	SuiteB128LOS       VerifyFlags = C.X509_V_FLAG_SUITEB_128_LOS
+	PartialChain       VerifyFlags = C.X509_V_FLAG_PARTIAL_CHAIN
+	NoAltChains        VerifyFlags = C.X509_V_FLAG_NO_ALT_CHAINS
+)
+
+func (s *CertificateStore) SetFlags(flags VerifyFlags) {
+	cflags := C.ulong(flags)
+	C.X509_STORE_set_flags(s.store, cflags)
+}
+
 type CertificateStoreCtx struct {
 	ctx     *C.X509_STORE_CTX
 	ssl_ctx *Ctx


### PR DESCRIPTION
Since the certificate store is passed into the `VerifyTrustAndGetIssuerCertificate`, it makes no sense to set the flags on it from inside that method.  So, I created a separate method on the certificate store object to handle any of the `X509_V_FLAG_*` flags which can be set on the store.  