### PR TITLE
Fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/spacemonkeygo/openssl
+module github.com/emtammaru/openssl
 
 require github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572


### PR DESCRIPTION
This change should fix this error when consuming this module:
```
go: github.com/emtammaru/openssl@v0.0.0-20201116211846-fee54f9ba0af: parsing go.mod:
	module declares its path as: github.com/spacemonkeygo/openssl
	        but was required as: github.com/emtammaru/openssl
```