### PR TITLE
Add function to parse RSA public key in PKCS1 format

### DIFF
--- a/rsa.go
+++ b/rsa.go
@@ -216,8 +216,8 @@ func ParseRSAPublicKeyPKCS1(publicKey []byte) (key *RSAPublicKey, err error) {
 
 	var n, e *C.BIGNUM
 	C.RSA_get0_key(rsa, &n, &e, nil)
-	defer C.BN_free(n)
-	defer C.BN_free(e)
+	// Note: purposely not calling BN_free on n & e, because they are cleaned up by RSA_free.
+	// Calling both results in an intermittent SIGTERM.
 
 	CmodulusHex := C.BN_bn2hex(n)
 	defer C.X_OPENSSL_free(unsafe.Pointer(CmodulusHex))

--- a/rsa.go
+++ b/rsa.go
@@ -19,6 +19,8 @@ import "C"
 import (
 	"errors"
 	"fmt"
+	"math/big"
+	"strconv"
 	"unsafe"
 )
 
@@ -186,4 +188,52 @@ func contains(items []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// RSAPublicKey represents the public part of an RSA key.
+type RSAPublicKey struct {
+	N *big.Int // modulus
+	E int      // public exponent
+}
+
+// This function specifically expects an RSA public key DER encoded in the PKCS#1 format
+func ParseRSAPublicKeyPKCS1(publicKey []byte) (key *RSAPublicKey, err error) {
+	inf := C.BIO_new(C.BIO_s_mem())
+	if inf == nil {
+		return nil, errors.New("failed allocating input buffer")
+	}
+	defer C.BIO_free(inf)
+	_, err = asAnyBio(inf).Write(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	rsa := C.d2i_RSA_PUBKEY_bio(inf, nil)
+	if rsa == nil {
+		return nil, errors.New("failed to load public key")
+	}
+	defer C.RSA_free(rsa)
+
+	var n, e *C.BIGNUM
+	C.RSA_get0_key(rsa, &n, &e, nil)
+	defer C.BN_free(n)
+	defer C.BN_free(e)
+
+	CmodulusHex := C.BN_bn2hex(n)
+	defer C.X_OPENSSL_free(unsafe.Pointer(CmodulusHex))
+	CexponentHex := C.BN_bn2hex(e)
+	defer C.X_OPENSSL_free(unsafe.Pointer(CexponentHex))
+
+	modulusHex := C.GoString(CmodulusHex)
+	exponentHex := C.GoString(CexponentHex)
+
+	ret := &RSAPublicKey{N: new(big.Int)}
+	ret.N.SetString(modulusHex, 16)
+	exponent, err := strconv.ParseInt(exponentHex, 16, 64)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert hex exponent to int: %v", err)
+	}
+	ret.E = int(exponent)
+
+	return ret, nil
 }

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2017. See AUTHORS.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openssl
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func Test_Unit_ParseRSAPublicKeyPKCS1(t *testing.T) {
+	rsaPubKeyHex := "30819f300d06092a864886f70d010101050003818d0030818902818100c66ee1df2b07469ec8a45d2307500cdd30fddf514356062a6e651ccdd667f050c462cca3932a7a1e28b59b20071a7897736b12fac21bbc5a66cc64e74adf222cef3dda627512efdbc89bf9a0d77dfcc33417110aaf218dbcb7090b95395535a557c0a621ab7dbdc764061fb3644141f363cd2bd82ce541a9e0a8f22b3e3581d70203010001"
+	rsaPubKeyDer, err := hex.DecodeString(rsaPubKeyHex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sut, err := ParseRSAPublicKeyPKCS1(rsaPubKeyDer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sut.E != 65537 {
+		t.Fatal()
+	}
+	actualN := hex.EncodeToString(sut.N.Bytes())
+	if actualN != "c66ee1df2b07469ec8a45d2307500cdd30fddf514356062a6e651ccdd667f050c462cca3932a7a1e28b59b20071a7897736b12fac21bbc5a66cc64e74adf222cef3dda627512efdbc89bf9a0d77dfcc33417110aaf218dbcb7090b95395535a557c0a621ab7dbdc764061fb3644141f363cd2bd82ce541a9e0a8f22b3e3581d7" {
+		t.Fatal(actualN)
+	}
+}


### PR DESCRIPTION
There's several different ways to do this in different versions of openssl.  In openssl v3, it can be done with `PEM_read_RSA_PUBKEY` and `EVP_PKEY_get_bn_param`.  To support v1, I had to go digging a little further.  There's an alternate function `d2i_RSAPublicKey_bio`, but it doesn't work for our specific format.  The function `d2i_RSA_PUBKEY_bio` is specifically for parsing keys in PKC#1 container which is what we need.

I generated the testdata for the unit test with the following commands:
```
openssl genrsa -out rsa.private 1024
openssl rsa -in rsa.private -out rsa.public -pubout -outform DER
```
